### PR TITLE
Update the szczur environment file to match current environment variable syntax

### DIFF
--- a/envs/szczur.yaml
+++ b/envs/szczur.yaml
@@ -25,21 +25,23 @@ Modsets:
         - gcc
         - gfortran
         - g++
-      MPI-PATH: /Users/duda/local/gcc-9.2.0
-      mpi-executables:
+    MPI:
+      version: 4.0.1
+      PATH: /Users/duda/local/gcc-9.2.0
+      executables:
         - mpicc
         - mpifort
         - mpic++
     libs:
       - p-netcdf:
-        ENV-NAME: PNETCDF
-        value: /Users/duda/local/gnu/9.2.0/lib
+        name: PNETCDF
+        value: /Users/duda/local/gnu/9.2.0
       - c-netcdf:
-        ENV-NAME: NETCDF
-        value: /Users/duda/local/gnu/9.2.0/lib
+        name: NETCDF
+        value: /Users/duda/local/gnu/9.2.0
       - f-netcdf:
-        ENV-NAME: NETCDFF
-        value: /Users/duda/local/gnu/9.2.0/lib
+        name: NETCDFF
+        value: /Users/duda/local/gnu/9.2.0
       - PIO:
-        ENV-NAME: PIO
-        value: /Users/duda/local/gnu/9.2.0/lib
+        name: PIO
+        value: /Users/duda/local/gnu/9.2.0


### PR DESCRIPTION
This merge updates the `szczur.yaml` environment file to match the current environment
variable syntax.

As of the merge commit 6f55178, the syntax for specifying environment variables
changed.