### PR TITLE
Add ability to automatically parse test configuration files 

### DIFF
--- a/smarts/testManager.py
+++ b/smarts/testManager.py
@@ -4,6 +4,7 @@ import sys
 import datetime
 from importlib import import_module
 from multiprocessing import Process
+import configparser
 
 from smarts.reporters.reporter import Result
 from smarts import hpc
@@ -23,9 +24,26 @@ FAILED = "FAILED"
 INCOMPLETE = "INCOMPLETE"
 
 class Test:
-    """ class Test - A base class for tests """
-    def __init__(self):
-        pass
+    def __init__(self, testDir, testName):
+        self.configFiles = []
+        test = os.path.join(testDir, testName)
+
+        """ For files that end with .cfg in the test directory, add them to self.configFiles """
+        for files in os.listdir(test):
+            if files.endswith(".cfg"):
+                self.configFiles.append(os.path.join(testDir, testName, files))
+
+        """ If there are any configFiles, then parse them via self.parse_config"""
+        if self.configFiles:
+            self.parse_config(self.configFiles)
+
+    def parse_config(self, configFiles):
+        """ Using the ConfigParser module, parse all configFiles. All parsed files can be accessed
+        in self.config """
+        self.config = configparser.ConfigParser()
+
+        for files in configFiles:
+            self.config.read(files)
 
 
 """ Class TestSubProcess - Wrapper for individual test to enable management of multiprocessing """
@@ -324,7 +342,14 @@ class TestManager:
         # TODO: Try except here
         module = import_module(test_launch_name+'.'+test_launch_name)
         test = getattr(module, test_launch_name) # Get the test from the module
-        test = test() # Initialize the test
+        try:
+            # Try to load the test, if its derived from the Test class, than we'll need to pass it
+            # the testDir and the test_launch_name, so it can read .cfg files. If this fails, then
+            # the test might not be derived by Test, so launch it normally in the except sections.
+            test = test(self.testDir, test_launch_name)
+        except:
+            test = test()
+
 
         testProcess = TestSubProcess(test_launch_name,
                                      test,

--- a/smarts/testManager.py
+++ b/smarts/testManager.py
@@ -22,6 +22,11 @@ PASSED = "PASSED"
 FAILED = "FAILED"
 INCOMPLETE = "INCOMPLETE"
 
+class Test:
+    """ class Test - A base class for tests """
+    def __init__(self):
+        pass
+
 
 """ Class TestSubProcess - Wrapper for individual test to enable management of multiprocessing """
 class TestSubProcess(Process):

--- a/tests/config_test/config_test.py
+++ b/tests/config_test/config_test.py
@@ -1,0 +1,22 @@
+import os
+from smarts.testManager import Test
+
+class config_test(Test):
+    test_name = "Config Test"
+    test_description = "Check to see if SMARTS2 configuration is working"
+    ncpus = 1
+
+    def run(self, env, result, src_dir, test_dir, hpc=None, *args, **kwargs):
+        result.result = "PASSED"
+        result.msg = "Configuration was correct!"
+
+        if self.config['setup']['mesh'] != 'x1.10242.grid.nc':
+            result.result="Failed"
+            result.msg = "setup.mesh was not x1.10242.grid.nc"
+
+        if self.config['Section2']['var1'] != 'var2':
+            result.result="Failed"
+            result.msg = "setup.mesh was not x1.10242.grid.nc"
+
+
+        return 0

--- a/tests/config_test/options.cfg
+++ b/tests/config_test/options.cfg
@@ -1,0 +1,3 @@
+[setup]
+mesh = x1.10242.grid.nc
+fields = [ter, soilcat, vegfrac]

--- a/tests/config_test/setup.cfg
+++ b/tests/config_test/setup.cfg
@@ -1,0 +1,2 @@
+[Section2]
+var1 = var2


### PR DESCRIPTION
This merge adds the ability that allows SMARTS to automatically parse configuration files for individual tests.

If any test contains a file with the extension `.cfg`, or multiple files with the `.cfg` extension, then the TestHandler will parse each file, using the Python configparser module and will passed into each test which can be accessed via `self.config`. Information on the syntax for `.cfg` files and accessing their configurations (via `self.config`) can be found at: https://docs.python.org/3/library/configparser.html.