### PR TITLE
Implement ability to pass CL options via config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,43 @@ You can use these arguments to help write your tests.
    to the HPC scheduler. If HPC == None, then this
    machine is not an HPC.
 
+# Smarts Config File .smartscf
+
+In the initial version of SMARTS2, the input arguments for running SMARTS are
+almost always the same and relay change between runs. While iterating on tests,
+the user will need to continually and, rather annoying, pass these same arguments
+over and over.
+
+In order to get rid of this annoyance, the user create a SMARTS config file to
+pass these arguments.
+
+This file will look like the following:
+
+```
+[smarts]
+environment = '/path/to/enviornment/file'
+tests_dir = '/path/to/test_dir/'
+source_dir = '/path/to/source_dir'
+verbose = 0
+```
+
+All of the above configurations are optional.
+
+The configuration file should be named `.smartscf` and can be placed in the two
+following locations:
+
+1. Users Directory: `~/.smartscf` 2. The current running/working directory
+`./.smartscf` (i.e. where you run SMARTS)
+
+SMARTS will try and read the configuration from both of these locations *and*
+take in command line arguments. Precedents for options will be taken in the
+following order (1 = highest priority).
+
+1. Command line options
+2. Current working directory .smartscf
+3. User config ~/.smartscf
+
+
 # Planned Features
 
 ## Beta Release - v0.5

--- a/smarts.py
+++ b/smarts.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function
 import os
 import sys
 import argparse
+from smarts.config import CommandLineConfig, SmartsCFConfig, SmartsConfig, SmartscfType
 from smarts.env import Environment
 from smarts.testManager import TestManager
 
@@ -70,6 +71,7 @@ def setup_smarts(envFile=None, testDir=None, srcDir=None):
     smarts TestManager - Will fail if any of the above files or directories
     do not exist """
 
+    print(testDir)
     if not os.path.isfile(envFile):
         print("ERROR: The environment.yaml file does not exist!")
         print("ERROR: Was it specified correctly?")
@@ -100,10 +102,8 @@ def list_cmd(args):
     """ SMARTS Command Line API for handling the list command passed in to
     the argparser. """
 
-    testDir = args.dir[0]
-    testDir = os.path.abspath(testDir) # Convert relative path into an absolute path
-    envFile = args.env[0]
-    envFile = os.path.abspath(envFile)
+    testDir = args.config.test_dir
+    envFile = args.config.env_file
 
     env, test_handler = setup_smarts(envFile, testDir)
 
@@ -140,65 +140,34 @@ def list_cmd(args):
 def run_cmd(args):
     """ SMARTS Command Line API for handling the run command passed in to
     the argparser. """
-    testDir = args.dir[0] # The directory that contains each test
-    srcDir = args.src[0]  # The directory that contains the code to be tested
-    envFile = args.env[0] # The environment.yaml file
+    testDir = args.config.test_dir
+    srcDir = args.config.test_dir
+    envFile = args.config.env_file
     tests = list(set(args.items))
 
-    env, test_handler = setup_smarts(envFile, testDir, srcDir)
+    env, test_handler = setup_smarts(envFile=envFile, testDir=testDir, srcDir=srcDir)
     test_handler.run_tests(tests, env)
 
     return 0
 
 
 if __name__ == "__main__":
-    """ SMARTs Command Line Argument Parsing """
-
-    parser = argparse.ArgumentParser(prog="smarts",
+    parser = argparse.ArgumentParser(prog="SMARTS",
                                      description="A regression testing system for MPAS",
-                                     epilog=None
-                                    )
+                                     epilog=None)
 
-    required = parser.add_argument_group('Required arguments')
-    optional = parser.add_argument_group('Optional arguments')
 
-    required.add_argument('-e', '--env-file',
-                        dest='env',
-                        help='The location of the env.yaml file',
-                        metavar='env.yaml',
-                        default=None,
-                        nargs=1)
-    required.add_argument('-s', '--src-dir',
-                        dest='src',
-                        help='The directory that holds the code to test changes (MPAS-Model)',
-                        metavar='dir',
-                        default=None,
-                        nargs=1)
-    required.add_argument('-t', '--test-dir',
-                        dest='dir',
-                        help='The location of the test directory',
-                        metavar='dir',
-                        default=None,
-                        nargs=1)
-
-    optional.add_argument('-v', '--verbose',
-                        dest='verbose',
-                        help="Output debug level",
-                        type=int,
-                        metavar='level',
-                        default=0,
-                        nargs=1)
-
+    config = SmartsConfig(parser)
 
     subparsers = parser.add_subparsers(dest='command',
-                                       description='command description',
-                                       help='Sub-command help message')
+                            description='command description',
+                            help='Sub-command help message')
 
     # List subcommand
     listParser = subparsers.add_parser('list',
-                                       help="List SMART's tests, test suites and compilers",
-                                       description='Description for list sub-command',
-                                       epilog='Epilog for list sub-command')
+                                    help="List SMART's tests, test suites and compilers",
+                                    description='Description for list sub-command',
+                                    epilog='Epilog for list sub-command')
     listParser.add_argument('items',
                             help='List items help message',
                             nargs='+')
@@ -206,46 +175,41 @@ if __name__ == "__main__":
 
     # Run subcommand
     runParser = subparsers.add_parser('run',
-                                      help="Run a test or a test-suite by name",
-                                      description='Description for run sub-command',
-                                      epilog='Epilog for run sub-command')
+                                    help="Run a test or a test-suite by name",
+                                    description='Description for run sub-command',
+                                    epilog='Epilog for run sub-command')
     runParser.add_argument('items',
-                           help='Run items help message',
-                           nargs='+')
+                        help='Run items help message',
+                        nargs='+')
     runParser.set_defaults(func=run_cmd)
 
     args = parser.parse_args()
     args.parser = parser
     args.listParser = listParser
     args.runParser = runParser
+    args.config = config
 
-    if not args.command: # If there no commands were passed in print help message
+    if args.command is None:
         parser.print_help()
         sys.exit(-1)
-    if args.command == 'run' and args.src is None:
-        parser.print_usage()
-        print("ERROR: Please provide a src directory: -s dir, --src-dir dir")
+
+    try:
+        args.config.test_dir
+    except ValueError as ve:
+        parser.print_help()
         sys.exit(-1)
-    elif args.command == 'run' and args.env is None:
-        parser.print_usage()
-        print("ERROR: Please provide a environment file: -e env.yaml, --env-file env.yaml")
-        sys.exit(-1)
-    elif args.command == 'run' and args.dir is None:
-        parser.print_usage()
-        print("ERROR: Please provide a test directory: -t dir, --test-dir dir")
+    
+    try:
+        args.config.src_dir
+    except ValueError as ve:
+        parser.print_help()
         sys.exit(-1)
 
-    if args.command == 'list' and args.dir is None:
-        parser.print_usage()
-        print("ERROR: Please provide a test directory -t dir, --test-dir dir")
-        sys.exit(-1)
-    elif args.command == 'list' and args.env is None:
-        parser.print_usage()
-        print("ERROR: Please provide a environment file: -e env.yaml, --env-file env.yaml")
+    try:
+        args.config.env_file
+    except ValueError as ve:
+        parser.print_help()
         sys.exit(-1)
 
 
-    # In conjuction with the .set_defaults(func=x) command, for both the listParser,
-    # and runParser, the argparser will call the function x, depending on what command
-    # was passed in to the argparser.
     args.func(args)

--- a/smarts/config.py
+++ b/smarts/config.py
@@ -1,0 +1,201 @@
+
+import os
+import sys
+from pathlib import Path
+from enum import Enum
+from dataclasses import dataclass
+
+import argparse
+
+from smarts.env import Environment
+import configparser as ConfigParser
+
+SMARTS_CONFIG_FNAME = '.smartscf'
+
+@dataclass
+class ConfigData:
+    environment_file : str
+    environment : Environment
+    test_directory : str
+    source_directory : str
+    verbose : int
+
+class Config:
+    def __init__(self, configData=None):
+        if configData is not None:
+            self._data = configData
+        else:
+            self._data = ConfigData(environment_file=None,
+                                    environment=None,
+                                    test_directory=None,
+                                    source_directory=None,
+                                    verbose=0)
+
+    @property
+    def env(self) -> Environment:
+        return self._data.environment
+
+    @env.setter
+    def env(self, value : Environment):
+        print("Setting enviornment file")
+        self._data.environment = value
+
+    @property
+    def env_file(self) -> str:
+        return self._data.environment_file
+
+    @env_file.setter
+    def env_file(self, value : str):
+        self._data.environment_file = value
+
+    @property
+    def test_dir(self) -> str:
+        return self._data.test_directory
+
+    @test_dir.setter
+    def test_dir(self, value : str):
+        self._data.test_directory = value
+
+    @property
+    def source_dir(self) -> str:
+        return self._data.source_directory
+
+    @source_dir.setter
+    def source_dir(self, value : str):
+        self._data.source_directory = value
+
+    @property
+    def verbose(self) -> int:
+        return self._data.verbose
+
+    @verbose.setter
+    def verbose(self, value : int):
+        self._data.verbose = value
+
+class CommandLineConfig(Config):
+    def __init__(self, parser):
+        super().__init__()
+        self.parser = parser
+        self.setup_argparse()
+
+    def setup_argparse(self):
+        print("Setting up optional argparse")
+        optional = self.parser.add_argument_group('Optional arguments')
+
+        optional.add_argument('-e', '--env-file',
+                            dest='env',
+                            help='The location of the env.yaml file',
+                            metavar='env.yaml',
+                            default=None)
+        optional.add_argument('-s', '--src-dir',
+                            dest='src',
+                            help='The directory that holds the code to test changes (MPAS-Model)',
+                            metavar='dir',
+                            default=None)
+        optional.add_argument('-t', '--test-dir',
+                            dest='dir',
+                            help='The location of the test directory',
+                            metavar='dir',
+                            default=None)
+
+        optional.add_argument('-v', '--verbose',
+                            dest='verbose',
+                            help="Output debug level",
+                            type=int,
+                            metavar='level',
+                            default=0)
+                        
+    def parse_config_arguments(self, args):
+        self.env_file = args.env
+        self.test_dir = args.dir
+        self.source_dir = args.src
+
+class SmartscfType(Enum):
+    USER = Path.home()
+    CWD = Path(os.getcwd())
+
+class SmartsCFConfig(Config):
+    def __init__(self, config_type : SmartscfType):
+        super().__init__()
+        self.smartsCfType=config_type
+        self.configParser = ConfigParser.ConfigParser()
+        if self.is_config_present():
+            self.parse_config()
+        else:
+            print("Config is not present")
+
+    @property
+    def config_location(self) -> str:
+        return os.path.join(self.smartsCfType.value, SMARTS_CONFIG_FNAME)
+
+    def is_config_present(self) -> bool:
+        return os.path.isfile(self.config_location)
+
+    def parse_config(self):
+        self.configParser.read(self.config_location)
+
+        if 'smarts' not in self.configParser.sections():
+            raise(ValueError(f"'[smarts]' section was not found in the config file {self.config_location}. "\
+                              "See the README for '.smartscf' exmaple"))
+
+        smarts_section = self.configParser['smarts']
+
+        if 'environment' in smarts_section:
+            self.env_file = os.path.expanduser(smarts_section['environment'])
+
+        if 'tests_dir' in smarts_section:
+            self.test_dir = os.path.expanduser(smarts_section['tests_dir'])
+
+        if 'source_dir' in smarts_section:
+            self.source_dir = os.path.expanduser(smarts_section['source_dir'])
+        
+        if 'verbose' in smarts_section:
+            self.verbose = os.path.expanduser(smarts_section['verbose'])
+
+
+class SmartsConfig:
+    def __init__(self, parser):
+        self.cl_config = CommandLineConfig(parser)
+        self.user_config = SmartsCFConfig(SmartscfType.USER)
+        self.cwd_config = SmartsCFConfig(SmartscfType.CWD)
+
+    @property
+    def test_dir(self):
+        if self.cl_config.test_dir is not None:
+            return self.cl_config.test_dir
+
+        if self.cwd_config.test_dir is not None:
+            return self.cwd_config.test_dir
+
+        if self.user_config.test_dir is not None:
+            return self.user_config.test_dir
+
+        raise ValueError(f'No test directory file was found in any configuration')
+
+    @property
+    def src_dir(self):
+        if self.cl_config.source_dir is not None:
+            return self.cl_config.source_dir
+
+        if self.cwd_config.source_dir is not None:
+            return self.cwd_config.source_dir
+
+        if self.user_config.source_dir is not None:
+            return self.user_config.source_dir
+
+        raise ValueError(f'No source directory file was found in any configuration')
+
+
+    @property
+    def env_file(self):
+        if self.cl_config.source_dir is not None:
+            return self.cl_config.env_file
+
+        if self.cwd_config.source_dir is not None:
+            return self.cwd_config.env_file
+
+        if self.user_config.source_dir is not None:
+            return self.user_config.env_file
+
+        raise ValueError(f'No enviornment file was found in any configuration')
+    


### PR DESCRIPTION
This commit enables the ability for users to pass command line options to SMARTs via configuration files.

Configuration files can be in either of two places:

1. User directory `~/.smartscf`
2. Current working directory `./.smartscf`

They allow users to pass the same options that can be passed via the command line, the environment file, the test directory, the source directory and the verbosity level.

On top of these files, the command line options can still be passed.

Smarts will try and read all of the above configuration files if they are present. Precedents for options will be taken in the following order (1 = highest priority):

1. Command line options
2. Current working directory `./.smartscf`
3. User config `~/.smartscf`